### PR TITLE
Deterministic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,6 +192,12 @@ check: check-bench
 	# as default, and test a minimal set of features with only one backend
 	# at a time.
 	cargo check --manifest-path lib/runtime/Cargo.toml
+	# Check some of the cases where deterministic execution could matter
+	cargo check --manifest-path lib/runtime/Cargo.toml --features "deterministic-execution"
+	cargo check --manifest-path lib/runtime/Cargo.toml --no-default-features \
+		--features=default-backend-singlepass,deterministic-execution
+	cargo check --manifest-path lib/runtime/Cargo.toml --no-default-features \
+		--features=default-backend-llvm,deterministic-execution
 	cargo check --release --manifest-path lib/runtime/Cargo.toml
 
 	$(RUNTIME_CHECK) \


### PR DESCRIPTION
This should fix things up so it can be merged in.

We can deal with the precise semantics later of things like the compiler returned by `Backend::Auto` here, but I think it's much simpler to avoid using the `deterministic` flag there for now